### PR TITLE
Translated component_ownerpermissions_option_close and proposed a different English version for it

### DIFF
--- a/Website/da/translation.json
+++ b/Website/da/translation.json
@@ -185,7 +185,7 @@
   "component_ownerpermissions_option_lfp": "Se efter mennesker",
   "component_ownerpermissions_option_users": "Betro/bloker brugere",
   "component_ownerpermissions_option_chat": "Brug stemmekanal chatten",
-  "component_ownerpermissions_option_close": "Force close channel",
+  "component_ownerpermissions_option_close": "Forcibly close channel",
 
   "component_category_title": "Midlertidig Kanalkategori (Primær)",
   "component_category_menu_lable": "Ingen Kategori Valgt",

--- a/Website/en/translation.json
+++ b/Website/en/translation.json
@@ -185,7 +185,7 @@
   "component_ownerpermissions_option_lfp": "Look for people (lfp)",
   "component_ownerpermissions_option_users": "Trust/block users",
   "component_ownerpermissions_option_chat": "Use in-voice chat",
-  "component_ownerpermissions_option_close": "Force close channel",
+  "component_ownerpermissions_option_close": "Forcibly close channel",
 
   "component_category_title": "Temporary Channel Category (Primary)",
   "component_category_menu_lable": "No Category Selected",

--- a/Website/it/translation.json
+++ b/Website/it/translation.json
@@ -185,7 +185,7 @@
   "component_ownerpermissions_option_lfp": "Cercare utenti (/voice lfp)",
   "component_ownerpermissions_option_users": "Aggiungere utenti fidati/bloccati",
   "component_ownerpermissions_option_chat": "Usare la chat in-voice",
-  "component_ownerpermissions_option_close": "Force close channel",
+  "component_ownerpermissions_option_close": "Chiudere forzatamente il canale",
 
   "component_category_title": "Categoria dei canali temporanei (principale)",
   "component_category_menu_lable": "Nessuna categoria",

--- a/Website/vi/translation.json
+++ b/Website/vi/translation.json
@@ -185,7 +185,7 @@
   "component_ownerpermissions_option_lfp": "Tìm kiếm người (lfp)",
   "component_ownerpermissions_option_users": " tin cậy/chặn người dùng",
   "component_ownerpermissions_option_chat": "Sử dụng trò chuyện thoại",
-  "component_ownerpermissions_option_close": "Force close channel",
+  "component_ownerpermissions_option_close": "Forcibly close channel",
   
   "component_category_title": "Danh mục kênh tạm thời (Cấp chính)",
   "component_category_menu_lable": "Không có danh mục nào được chọn",


### PR DESCRIPTION
using an adverb was more correct, this is my source: https://thecontentauthority.com/blog/forcibly-vs-forcefully